### PR TITLE
added required classes for horizontal home-img align center

### DIFF
--- a/app/pods/index/template.hbs
+++ b/app/pods/index/template.hbs
@@ -14,7 +14,7 @@
         {{#carousel-cards}}
         {{/carousel-cards}}
     </div>
-    <div class="col-xs-12 col-md-6">
+    <div class="col-xs-12 col-sm-12 home-img-box">
         <img class="home-img" src="images/home.png" alt="home">
     </div>
 </div>


### PR DESCRIPTION
required changes for https://github.com/coding-blocks/motley/issues/130.
Motley PR: https://github.com/coding-blocks/motley/pull/139
Same alignment as shown earlier: 
![screen shot 2018-05-15 at 12 24 49 pm](https://user-images.githubusercontent.com/22571395/40041319-2c208a60-583b-11e8-917a-6af5a04d3c75.png)