### PR TITLE
make sure loaders show up

### DIFF
--- a/app/pods/attempt/loading/template.hbs
+++ b/app/pods/attempt/loading/template.hbs
@@ -1,0 +1,1 @@
+{{loader-component}}

--- a/app/pods/attempt/route.js
+++ b/app/pods/attempt/route.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 
 export default Route.extend({
     model (params) {
-        return this.store.findRecord('runAttempt', params.runAttemptId)
+        return this.store.findRecord('runAttempt', params.runAttemptId, {reload: true})
     },
     setupController(controller, model) {
         this._super(...arguments)

--- a/app/pods/classroom/loading/template.hbs
+++ b/app/pods/classroom/loading/template.hbs
@@ -1,0 +1,1 @@
+{{loader-component}}


### PR DESCRIPTION
This makes sure loaders show up for `classroom.timeline` and `attempt.content` transitions. 

Future Todo: Vertically center loaders, according to their layout.