### PR TITLE
Notification box behaviour is corrected against clicking events.

### DIFF
--- a/app/pods/components/notification-dropdown/component.js
+++ b/app/pods/components/notification-dropdown/component.js
@@ -14,6 +14,7 @@ export default class NotificationDropdownComponent extends Component {
 
   active = false
   iconWasClicked = false
+  clickedOnNotifyBox = false
   notifications = []
   unreadNotifications = true
 
@@ -35,8 +36,31 @@ export default class NotificationDropdownComponent extends Component {
   }
 
   didInsertElement() {
-    this.$(document).on("click", ":not(#notfication-box)", () => {
-      this.toggleProperty('active') // toggle when clicked outside the notification box
+
+    // CHECKS IF NOTIFICATION BOX IS CLICKED OR NOT
+    // SETS FLAG ACCORDINGLY
+    this.$('#notification-box').on("click", () => {
+      this.toggleProperty("clickedOnNotifyBox")
+    });
+
+    // TOGGLES THE ACTIVE STATUS IF IT IS TRUE ALREADY
+    // AND NOTIFICATION ICON & NOTIFICATION BOX ARE NOT
+    // CLICKED!
+    this.$(document).on("click", () => {
+      let isPresent = this.get('active')
+      let avoidable2 = this.get('iconWasClicked')
+      let avoidable1 = this.get('clickedOnNotifyBox')
+      if (!avoidable2 && isPresent && !avoidable1) {
+        this.toggleProperty ("active")
+      }
+      // BELOW CODE RESETS THE FLAGS SO THAT THEY CAN
+      // BE USED FOR CLICK EVENTS IN FUTURE (NEXT CLICK EVENTS)
+      if (avoidable1) {
+        this.toggleProperty('clickedOnNotifyBox')  
+      }
+      if (avoidable2) {
+        this.toggleProperty('iconWasClicked')
+      }
     });
   }
 
@@ -74,7 +98,10 @@ export default class NotificationDropdownComponent extends Component {
 
   @action
   toggle () {
-    this.get ('loadNotifications').perform ()
+    this.get('loadNotifications').perform ()
+    this.toggleProperty ("active")
+    this.toggleProperty("iconWasClicked")
+    return
   }
 
   @action

--- a/app/pods/components/notification-dropdown/template.hbs
+++ b/app/pods/components/notification-dropdown/template.hbs
@@ -5,7 +5,7 @@
 	<img src="/images/notif-icon.png" alt="">
 </div>
 
-<div class="dropdown-ul o-notification {{if active 'display-block'}}" id="notfication-box">
+<div class="dropdown-ul o-notification {{if active 'display-block'}}" id="notification-box">
 	{{#if notifications.length}}
 		{{#each notifications as |notification|}}
 		<a href="{{notification.url}}" target="_blank">


### PR DESCRIPTION
**Corrected the behavior of notification box against clicking actions.**

_Now:_
- Clicking on notify-icon opens the notification box (if not opened already)
- Clicking anywhere on the page would close the notification box **except if the click is on notification-box itself**
@abhishek97 Take a look at it, this reaches the expected behavior of notification box.