### PR TITLE
Aligned playback speed icon

### DIFF
--- a/app/pods/components/hls-player/template.hbs
+++ b/app/pods/components/hls-player/template.hbs
@@ -8,5 +8,5 @@
 	    <i class="fa fa-fast-forward"></i>
 	    </button>
 	</div>
-    <label id="playback-speed">{{pr}}X</label>
+    <label id="playback-speed">{{pr}}x</label>
 </div>

--- a/app/styles/objects/o-video-player/video-player.scss
+++ b/app/styles/objects/o-video-player/video-player.scss
@@ -9,7 +9,7 @@
     display: none;
     @include border-radius(3px);
     position: absolute;
-    bottom: 45px;
+    bottom: 565px;
     right: 15px;
     width: 33px;
     color: $white;


### PR DESCRIPTION
Resolves issue 16. Screenshots in the parent PR

Playback speed icon is now aligned to the top right in medium/big screens, and bottom (default behaviour) for mobile screens