### PR TITLE
use "items" instead of "lectures"

### DIFF
--- a/app/pods/components/accordion-head/template.hbs
+++ b/app/pods/components/accordion-head/template.hbs
@@ -41,7 +41,7 @@
 		<div class="li-right col-4">
 			{{#if total}}
 				<div class="col-12 col-sm-6">
-					{{total}} Lectures
+					{{total}} Items
 				</div>
 			{{else}}
 				<div class="col-12 col-sm-6">


### PR DESCRIPTION
the total in the accordian is of total lectures + quizzes + docs etc. So should say items not lectures.

### Make your PR against development branch only


### Is this PR regarding CSS? 
This project uses motley(https://github.com/coding-blocks/motley/) as css framework. We don't accept css changes here. Please consider a PR to motley instead
